### PR TITLE
Do not use gzip

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const handleRequest = (httpsAgent) => async (req, res) => {
   const options = {
     hostname: k8sUrl.hostname,
     path: req.originalUrl,
-    headers: req.headers,
+    headers: { ...req.headers, "Accept-Encoding": "" }, // a bit of explaination: k8s API handles accepting gzip but randomly decides to actually use it or not.
     body: req.body,
     agent: httpsAgent,
     method: req.method,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
K8s Rest API accepts `Accept-Encoding: gzip` header (sent by most browsers by default)  but randomly choses whether or not to actually use the Gzip compression.
Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
